### PR TITLE
Add meson build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-Vftrace can be installed using autotools.
+Vftrace can be installed using autotools or meson.
 
 autoreconf -i
 ./configure CC=<your_C_compiler> CXX=<your_C++_compiler> FC=<your_Fortran_compiler> --prefix=<install_path>
@@ -12,3 +12,15 @@ o --enable-veperf / --disable-veperf: Switch on/off Veperf support (SX Aurora on
 o --enable-mpi-profiling: Switch on MPI profiling. In this case, MPI function calls are overloaded. Internally, the PMPI functions are used, which have to be supported by your compile environment.
 o --enable-vmap-offset: On some systems, function instrumentation leads to offsets in the virtual memory maps, which has to be subtracted from the symbol addresses in order
 			to get proper name resolution. This option enables this feature.
+
+The build option with meson requires a recent meson installation, see https://mesonbuild.com/Getting-meson.html, and/or a recent Ninja installation, https://ninja-build.org/.
+Both tools can be downloaded as binaries and added to the project's directory.
+
+CC=<C Compiler> CXX=<C++ compiler> FC=<Fortran compiler> meson <build directory> --prefix=<install path>
+cd <build directory>
+ninja
+ninja install
+
+The meson build supports the same build options as autotools, however, the syntax is different:
+o -D<option name>=<enabled/disabled|string|true/false>
+For detailed view of the build options, see meson help configure and meson_options.txt.

--- a/install_vftrace_mod.sh
+++ b/install_vftrace_mod.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Expect prefix and include dir
+DESTDIR="${1}/${2}"
+
+VFTRACE_MOD="$(find ${MESON_BUILD_ROOT} -name 'vftrace.mod')"
+cp -a "${VFTRACE_MOD}" "${DESTDIR}"

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,8 @@ project('vftrace',
         # see 'meson configure' (in build directory) for all available options
         default_options : [
           'default_library=static',
-          'buildtype=release'
+          'buildtype=debug',
+          'fortran_std=none'
         ])
 
 # GCC10 introduced a paradigm-change by defaulting to -fno-common, https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common.
@@ -20,6 +21,7 @@ endif
 
 # C / C++
 cc = meson.get_compiler('c')
+libmath_dep = cc.find_library('m', required : false) # Only needed for subproject dependency.
 if not cc.has_argument('-finstrument-functions')
   error('C compiler has no support for "-finstrument-functions"')
 endif
@@ -29,8 +31,8 @@ if not cpp.has_argument('-finstrument-functions')
 endif
 
 dldep = cc.find_library('dl')
-mpi = dependency('mpi', language : 'fortran', required : get_option('mpi-profiling'))
-if mpi.found ()
+mpi_dep = dependency('mpi', language : 'fortran', required : get_option('mpi-profiling'))
+if mpi_dep.found ()
   add_project_arguments('-D_MPI', language: ['c', 'cpp', 'fortran'])
   if fortran.get_id() == 'intel'
     add_project_arguments('-DPMPI_MODULE=pmpi_f08', language : 'fortran')
@@ -49,9 +51,17 @@ if get_option('veperf').enabled()
 endif
 
 # Add VMAP offset check using config_test.sh
+if get_option('vmap-offset').enabled()
+  message('Use VMAP offset')
+  add_project_arguments('-D__VMAP_OFFSET', language : 'c')
+endif
 
 # Workaround: Install vftrace.mod
 meson.add_install_script('install_vftrace_mod.sh', get_option('prefix'), get_option('includedir'))
 
 subdir('src')
 subdir('share_src/man/man1')
+
+libvftrace_dep = declare_dependency(include_directories : inc_dep,
+                                    dependencies : libmath_dep,
+                                    link_with : [libvftrace, libvftr_dlopen])

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('vftrace',
         ['c', 'cpp', 'fortran'],
         license : 'GPL2+',
         version : '0.0',
-        meson_version : '>=0.55.0'
+        meson_version : '>=0.55.0',
         # see 'meson configure' (in build directory) for all available options
         default_options : [
           'default_library=static',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,57 @@
+project('vftrace',
+        ['c', 'cpp', 'fortran'],
+        license : 'GPL2+',
+        version : '0.0',
+        # see 'meson configure' (in build directory) for all available options
+        default_options : [
+          'default_library=static',
+          'buildtype=release'
+        ])
+
+# GCC10 introduced a paradigm-change by defaulting to -fno-common, https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common.
+# Rollback to previous behavior: -fcommon.
+add_project_arguments('-fcommon', language : ['c', 'cpp', 'fortran'])
+
+# Fortran
+fortran = meson.get_compiler('fortran')
+if not fortran.has_argument('-finstrument-functions')
+  error('Fortran compiler has no support for "-finstrument-functions"')
+endif
+
+# C / C++
+cc = meson.get_compiler('c')
+if not cc.has_argument('-finstrument-functions')
+  error('C compiler has no support for "-finstrument-functions"')
+endif
+cpp = meson.get_compiler('cpp')
+if not cpp.has_argument('-finstrument-functions')
+  error('C++ compiler has no support for "-finstrument-functions"')
+endif
+
+dldep = cc.find_library('dl')
+mpi = dependency('mpi', language : 'fortran', required : get_option('mpi-profiling'))
+if mpi.found ()
+  add_project_arguments('-D_MPI', language: ['c', 'cpp', 'fortran'])
+  if fortran.get_id() == 'intel'
+    add_project_arguments('-DPMPI_MODULE=pmpi_f08', language : 'fortran')
+  else
+    add_project_arguments('-DPMPI_MODULE=mpi', language : 'fortran')
+  endif
+endif
+
+if get_option('papi').enabled()
+  add_project_arguments('-DHAS_PAPI -I@0@'.format(get_option('papi-dir')), language : ['c', 'cpp'])
+endif
+
+if get_option('veperf').enabled()
+  add_project_arguments('-DHAS_VEPERF -I@0@'.format(get_option('veperf-dir')), language : ['c', 'cpp'])
+  add_project_link_arguments('-L@0@/lib -lveperf_ext'.format(get_option('veperf-dir')))
+endif
+
+# Add VMAP offset check using config_test.sh
+
+# Workaround: Install vftrace.mod
+meson.add_install_script('install_vftrace_mod.sh', get_option('prefix'), get_option('includedir'))
+
+subdir('src')
+subdir('share_src/man/man1')

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('vftrace',
         ['c', 'cpp', 'fortran'],
         license : 'GPL2+',
         version : '0.0',
+        meson_version : '>=0.55.0'
         # see 'meson configure' (in build directory) for all available options
         default_options : [
           'default_library=static',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,7 @@
+option('papi', type : 'feature', value : 'disabled', description : 'enable PAPI')
+option('papi-dir', type : 'string', value : '', description : 'assume given directory for PAPI')
+option('veperf', type : 'feature', value : 'disabled', description : 'enable VEPERF for SX Aurora')
+option('veperf-dir', type : 'string', value : '', description : 'assume given directory for VEPERF')
+option('mpi-profiling', type : 'feature', value : 'disabled', description : 'enable MPI profiling')
+option('vmap-offset', type : 'feature', value : 'disabled', description : 'enable VMAP offset')
+option('vmap-offset-check', type : 'boolean', value : true, description : 'enable VMAP offset check')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,5 +3,5 @@ option('papi-dir', type : 'string', value : '', description : 'assume given dire
 option('veperf', type : 'feature', value : 'disabled', description : 'enable VEPERF for SX Aurora')
 option('veperf-dir', type : 'string', value : '', description : 'assume given directory for VEPERF')
 option('mpi-profiling', type : 'feature', value : 'disabled', description : 'enable MPI profiling')
-option('vmap-offset', type : 'feature', value : 'disabled', description : 'enable VMAP offset')
+option('vmap-offset', type : 'feature', value : 'enabled', description : 'enable VMAP offset')
 option('vmap-offset-check', type : 'boolean', value : true, description : 'enable VMAP offset check')

--- a/share_src/man/man1/meson.build
+++ b/share_src/man/man1/meson.build
@@ -1,0 +1,1 @@
+install_man('vftrace.1')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,48 +1,53 @@
 install_headers('vftrace.h')
 
 libvftr_mpi = static_library('vftr_mpi', [
-                       'vftr_sync_messages.c',
-                       'vftr_async_messages.c',
-                       'vftr_mpi_utils.c',
-                       'vftr_mpi_environment.c',
-                       'vftr_mpi_environment_F.c',
-                       'vftr_mpi_environment_F08.c',
-                       'vftr_mpi_point2point.c',
-                       'vftr_mpi_point2point_F.c',
-                       'vftr_mpi_collective.c',
-                       'vftr_mpi_collective_F.c',
-                       'vftr_mpi_onesided.c',
-                       'vftr_mpi_onesided_F.c',
-                       'vftr_mpi_testwait.c',
-                       'vftr_mpi_testwait_F.c',
-                       'vftr_mpi_buf_addr_const.c',
-                       'vftr_mpi_buf_addr_const_F.F90',
-                     ])
+                              'vftr_sync_messages.c',
+                              'vftr_async_messages.c',
+                              'vftr_mpi_utils.c',
+                              'vftr_mpi_environment.c',
+                              'vftr_mpi_environment_F.c',
+                              'vftr_mpi_environment_F08.c',
+                              'vftr_mpi_point2point.c',
+                              'vftr_mpi_point2point_F.c',
+                              'vftr_mpi_collective.c',
+                              'vftr_mpi_collective_F.c',
+                              'vftr_mpi_onesided.c',
+                              'vftr_mpi_onesided_F.c',
+                              'vftr_mpi_testwait.c',
+                              'vftr_mpi_testwait_F.c',
+                              'vftr_mpi_buf_addr_const.c',
+                              'vftr_mpi_buf_addr_const_F.F90',
+                            ])
 
 libvftr_mpiwrap = static_library('vftr_mpiwrap', [
-                           'vftr_mpi_environment_cwrap.c',
-                           'vftr_mpi_environment_c2F.F90',
-                           'vftr_mpi_environment_Fwrap.F90',
-                           'vftr_mpi_environment_c2F08.F90',
-                           'vftr_mpi_environment_F08wrap.F90',
-                           'vftr_mpi_point2point_cwrap.c',
-                           'vftr_mpi_point2point_c2F.F90',
-                           'vftr_mpi_point2point_Fwrap.F90',
-                           'vftr_mpi_collective_cwrap.c',
-                           'vftr_mpi_collective_c2F.F90',
-                           'vftr_mpi_collective_Fwrap.F90',
-                           'vftr_mpi_onesided_cwrap.c',
-                           'vftr_mpi_onesided_c2F.F90',
-                           'vftr_mpi_onesided_Fwrap.F90',
-                           'vftr_mpi_testwait_cwrap.c',
-                           'vftr_mpi_testwait_c2F.F90',
-                           'vftr_mpi_testwait_Fwrap.F90'
-                         ],
-                          c_args : '-finstrument-functions',
-                          fortran_args : '-finstrument-functions')
+                                  'vftr_mpi_environment_cwrap.c',
+                                  'vftr_mpi_environment_c2F.F90',
+                                  'vftr_mpi_environment_Fwrap.F90',
+                                  'vftr_mpi_environment_c2F08.F90',
+                                  'vftr_mpi_environment_F08wrap.F90',
+                                  'vftr_mpi_point2point_cwrap.c',
+                                  'vftr_mpi_point2point_c2F.F90',
+                                  'vftr_mpi_point2point_Fwrap.F90',
+                                  'vftr_mpi_collective_cwrap.c',
+                                  'vftr_mpi_collective_c2F.F90',
+                                  'vftr_mpi_collective_Fwrap.F90',
+                                  'vftr_mpi_onesided_cwrap.c',
+                                  'vftr_mpi_onesided_c2F.F90',
+                                  'vftr_mpi_onesided_Fwrap.F90',
+                                  'vftr_mpi_testwait_cwrap.c',
+                                  'vftr_mpi_testwait_c2F.F90',
+                                  'vftr_mpi_testwait_Fwrap.F90'
+                                ],
+                                 c_args : '-finstrument-functions',
+                                 fortran_args : '-finstrument-functions')
 
-libvftr_pause = static_library('vftr_pause', ['vftr_pause.c'], c_args : '-finstrument-functions')
+libvftr_pause = static_library('vftr_pause', [
+                                'vftr_pause.c'
+                              ],
+                               c_args : '-finstrument-functions')
 
+# Use link_whole to link the complete content of the static libraries into shared library else the linker will not add them as the symbols in the static library are not (directly) used.
+# Add explicit (Fortran) MPI dependency to correctly link against MPI library without changing the link language, thus, the MPI wrapper.
 libvftrace = library('vftrace', [
                       'demangle.cpp',
                       'vftr_scenarios.c',
@@ -66,13 +71,16 @@ libvftrace = library('vftrace', [
                       'vftr_loadbalance.c',
                       'vftrace_mod.F90'
                     ],
-                     link_with :[
+                     link_whole : [
                        libvftr_pause,
-                       libvftr_mpiwrap,
-                       libvftr_mpi
+                       libvftr_mpi,
+                       libvftr_mpiwrap
                      ],
+                     dependencies : mpi_dep,
                      install : true)
 
 libvftr_dlopen = library('vftr_dlopen', ['vftr_dlopen.c'],
                          dependencies : dldep,
                          install : true)
+
+inc_dep = include_directories('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,78 @@
+install_headers('vftrace.h')
+
+libvftr_mpi = static_library('vftr_mpi', [
+                       'vftr_sync_messages.c',
+                       'vftr_async_messages.c',
+                       'vftr_mpi_utils.c',
+                       'vftr_mpi_environment.c',
+                       'vftr_mpi_environment_F.c',
+                       'vftr_mpi_environment_F08.c',
+                       'vftr_mpi_point2point.c',
+                       'vftr_mpi_point2point_F.c',
+                       'vftr_mpi_collective.c',
+                       'vftr_mpi_collective_F.c',
+                       'vftr_mpi_onesided.c',
+                       'vftr_mpi_onesided_F.c',
+                       'vftr_mpi_testwait.c',
+                       'vftr_mpi_testwait_F.c',
+                       'vftr_mpi_buf_addr_const.c',
+                       'vftr_mpi_buf_addr_const_F.F90',
+                     ])
+
+libvftr_mpiwrap = static_library('vftr_mpiwrap', [
+                           'vftr_mpi_environment_cwrap.c',
+                           'vftr_mpi_environment_c2F.F90',
+                           'vftr_mpi_environment_Fwrap.F90',
+                           'vftr_mpi_environment_c2F08.F90',
+                           'vftr_mpi_environment_F08wrap.F90',
+                           'vftr_mpi_point2point_cwrap.c',
+                           'vftr_mpi_point2point_c2F.F90',
+                           'vftr_mpi_point2point_Fwrap.F90',
+                           'vftr_mpi_collective_cwrap.c',
+                           'vftr_mpi_collective_c2F.F90',
+                           'vftr_mpi_collective_Fwrap.F90',
+                           'vftr_mpi_onesided_cwrap.c',
+                           'vftr_mpi_onesided_c2F.F90',
+                           'vftr_mpi_onesided_Fwrap.F90',
+                           'vftr_mpi_testwait_cwrap.c',
+                           'vftr_mpi_testwait_c2F.F90',
+                           'vftr_mpi_testwait_Fwrap.F90'
+                         ],
+                          c_args : '-finstrument-functions',
+                          fortran_args : '-finstrument-functions')
+
+libvftr_pause = static_library('vftr_pause', ['vftr_pause.c'], c_args : '-finstrument-functions')
+
+libvftrace = library('vftrace', [
+                      'demangle.cpp',
+                      'vftr_scenarios.c',
+                      'vftr_symbols.c',
+                      'vftr_hwcounters.c',
+                      'vftr_hooks.c',
+                      'vftr_setup.c',
+                      'vftr_filewrite.c',
+                      'vftr_fileutils.c',
+                      'vftr_hashing.c',
+                      'vftr_sorting.c',
+                      'vftr_stacks.c',
+                      'vftr_user_stack.c',
+                      'vftr_functions.c',
+                      'vftr_regions.c',
+                      'vftr_timer.c',
+                      'tinyexpr.c',
+                      'vftr_regex.c',
+                      'vftr_environment.c',
+                      'vftr_signals.c',
+                      'vftr_loadbalance.c',
+                      'vftrace_mod.F90'
+                    ],
+                     link_with :[
+                       libvftr_pause,
+                       libvftr_mpiwrap,
+                       libvftr_mpi
+                     ],
+                     install : true)
+
+libvftr_dlopen = library('vftr_dlopen', ['vftr_dlopen.c'],
+                         dependencies : dldep,
+                         install : true)


### PR DESCRIPTION
I propose to add the meson build system, concurrently, to the autotools build chain.
The addition of meson is completely orthogonal to autotools setup, thus, both can exist side-by-side.
However, at the cost of higher build system maintenance.

In order to build with meson, one requires meson and ninja (both can be downloaded as binaries).

An advantage of the meson build system, we use Vftrace as subproject to any project using meson, hence, no need for a standalone installation of Vftrace and manual addition of linker flags.